### PR TITLE
Remove pod version instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Teads SDK is currently distributed through CocoaPods. It include everything you 
 
 ```
 target 'YourProject' do
-    pod 'TeadsSDK', '4.8.0'
+    pod 'TeadsSDK'
 end
 ```
 
@@ -30,7 +30,7 @@ $ pod install --repo-update
 [Carthage](https://github.com/Carthage/Carthage) is a decentralized dependency manager that builds your dependencies and provides you with binary frameworks. To integrate TeadsSDK into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "teads/TeadsSDK-iOS" "4.8.0"
+github "teads/TeadsSDK-iOS"
 ```
 
 ## Integration Documentation


### PR DESCRIPTION
In documentation and sample we encourage to write pod TeadsSDK, '4.8.0' we should remove it