### PR TITLE
hide / show adView relative to onSlotStartHide / onSlotStartShow WKScriptMessage events

### DIFF
--- a/TeadsSampleApp/WebViewHelper/TeadsWebViewHelper.swift
+++ b/TeadsSampleApp/WebViewHelper/TeadsWebViewHelper.swift
@@ -259,11 +259,13 @@ import WebKit
             case .onTeadsJsLibReady:
                 insertSlot()
             case .onSlotStartShow:
+                adView?.isHidden = false
                 // the bootstrap calls this when the slot starts to show
                 delegate?.webViewHelperSlotStartToShow()
             case .onSlotUpdated:
                 onSlotUpdated(position: message.body as? String)
             case .onSlotStartHide:
+                adView?.isHidden = true
                 // the bootstrap calls this when the slot starts to hide
                 delegate?.webViewHelperSlotStartToHide()
             case .handleError:


### PR DESCRIPTION
ability to show / hide adView from HTML by calling
`javascript:window.teads.hidePlaceholder(0) // hide HTML element and TeadsAdView `
`javascript:window.teads.showPlaceholder(0) // show HTML element and TeadsAdView`