### PR TITLE
Add Interstitial AdMob demo screen

### DIFF
--- a/TeadsSampleApp/Controllers/Interstitial/Admob/InterstitialAdmobViewController.swift
+++ b/TeadsSampleApp/Controllers/Interstitial/Admob/InterstitialAdmobViewController.swift
@@ -9,7 +9,6 @@ import GoogleMobileAds
 import UIKit
 
 final class InterstitialAdmobViewController: TeadsViewController {
-
     private var interstitialAd: InterstitialAd?
     private var isContentUnlocked = false
     private var isWaitingForAd = false

--- a/TeadsSampleApp/Controllers/Interstitial/Admob/InterstitialAdmobViewController.swift
+++ b/TeadsSampleApp/Controllers/Interstitial/Admob/InterstitialAdmobViewController.swift
@@ -1,0 +1,320 @@
+//
+//  InterstitialAdmobViewController.swift
+//  TeadsSampleApp
+//
+//  Copyright © 2026 Teads. All rights reserved.
+//
+
+import GoogleMobileAds
+import UIKit
+
+class InterstitialAdmobViewController: TeadsViewController {
+    private var interstitialAd: InterstitialAd?
+    private var isContentUnlocked = false
+    private var isWaitingForAd = false
+
+    private let scrollView = UIScrollView()
+    private let contentStack = UIStackView()
+    private var paywallContainer: UIView?
+    private var watchAdButton: UIButton?
+    private var spinner: UIActivityIndicatorView?
+
+    // Article paragraphs
+    private let articleTitle = "The Future of Digital Advertising"
+    private let previewParagraph = """
+    The digital advertising landscape is undergoing a profound transformation. \
+    As privacy regulations tighten and third-party cookies phase out, publishers \
+    and advertisers are rethinking how they connect with audiences. New formats \
+    like interstitial ads offer immersive, full-screen experiences that capture \
+    attention while respecting user choice.
+    """
+    private let lockedParagraphs = [
+        """
+        Interstitial ads have emerged as one of the most effective ad formats for mobile apps. \
+        Unlike banner ads that compete for attention within a crowded interface, interstitials \
+        command the full screen, delivering higher engagement rates and better brand recall. \
+        Publishers who integrate interstitials at natural transition points — between articles, \
+        levels, or content sections — see significantly improved monetization without sacrificing \
+        user experience.
+        """,
+        """
+        The key to successful interstitial implementation lies in timing and relevance. \
+        Ads shown at natural content breaks feel less intrusive than those interrupting \
+        active engagement. Combined with server-side optimization for ad quality and \
+        frequency capping, interstitials can achieve the delicate balance between revenue \
+        generation and user satisfaction that every publisher seeks.
+        """,
+        """
+        Looking ahead, the convergence of contextual targeting, first-party data, and \
+        premium ad formats like interstitials will define the next era of digital advertising. \
+        Publishers who invest in these capabilities today will be best positioned to thrive \
+        in a privacy-first world where user trust is the ultimate currency.
+        """,
+    ]
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        setupUI()
+        loadInterstitialAd()
+    }
+
+    // MARK: - UI Setup
+
+    private func setupUI() {
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(scrollView)
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+
+        contentStack.axis = .vertical
+        contentStack.spacing = 0
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.addSubview(contentStack)
+        NSLayoutConstraint.activate([
+            contentStack.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            contentStack.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentStack.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            contentStack.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            contentStack.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+        ])
+
+        rebuildContent()
+    }
+
+    private func rebuildContent() {
+        contentStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
+
+        // Title
+        let titleLabel = UILabel()
+        titleLabel.text = articleTitle
+        titleLabel.font = .systemFont(ofSize: 24, weight: .bold)
+        titleLabel.numberOfLines = 0
+        titleLabel.textColor = .label
+        let titleWrapper = wrapWithPadding(titleLabel)
+        contentStack.addArrangedSubview(titleWrapper)
+
+        // Preview paragraph
+        let previewLabel = UILabel()
+        previewLabel.text = previewParagraph
+        previewLabel.font = .systemFont(ofSize: 16)
+        previewLabel.numberOfLines = 0
+        previewLabel.textColor = .secondaryLabel
+        let previewWrapper = wrapWithPadding(previewLabel)
+        contentStack.addArrangedSubview(previewWrapper)
+
+        if isContentUnlocked {
+            // Show all locked paragraphs
+            for paragraph in lockedParagraphs {
+                let label = UILabel()
+                label.text = paragraph
+                label.font = .systemFont(ofSize: 16)
+                label.numberOfLines = 0
+                label.textColor = .secondaryLabel
+                let wrapper = wrapWithPadding(label)
+                contentStack.addArrangedSubview(wrapper)
+            }
+        } else {
+            // Paywall overlay
+            let paywall = buildPaywall()
+            contentStack.addArrangedSubview(paywall)
+            paywallContainer = paywall
+        }
+    }
+
+    private func buildPaywall() -> UIView {
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+
+        // Faded preview text
+        let fadedLabel = UILabel()
+        fadedLabel.text = lockedParagraphs.first
+        fadedLabel.font = .systemFont(ofSize: 16)
+        fadedLabel.numberOfLines = 4
+        fadedLabel.textColor = .secondaryLabel
+        fadedLabel.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(fadedLabel)
+
+        // Gradient overlay
+        let gradientContainer = GradientView()
+        gradientContainer.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(gradientContainer)
+
+        // Paywall card
+        let card = UIView()
+        card.backgroundColor = .secondarySystemBackground
+        card.layer.cornerRadius = 12
+        card.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        card.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(card)
+
+        // Card content
+        let cardStack = UIStackView()
+        cardStack.axis = .vertical
+        cardStack.alignment = .center
+        cardStack.spacing = 12
+        cardStack.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(cardStack)
+
+        let premiumLabel = UILabel()
+        premiumLabel.text = "Premium Content"
+        premiumLabel.font = .systemFont(ofSize: 18, weight: .bold)
+        premiumLabel.textColor = .label
+        cardStack.addArrangedSubview(premiumLabel)
+
+        let descLabel = UILabel()
+        descLabel.text = "Watch an ad to read the rest of the article"
+        descLabel.font = .systemFont(ofSize: 14)
+        descLabel.textColor = .secondaryLabel
+        descLabel.textAlignment = .center
+        descLabel.numberOfLines = 0
+        cardStack.addArrangedSubview(descLabel)
+
+        let button = UIButton(type: .system)
+        button.setTitle("Watch Ad", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 16, weight: .semibold)
+        button.backgroundColor = .systemBlue
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 8
+        button.contentEdgeInsets = UIEdgeInsets(top: 12, left: 32, bottom: 12, right: 32)
+        button.addTarget(self, action: #selector(watchAdTapped), for: .touchUpInside)
+        cardStack.addArrangedSubview(button)
+        watchAdButton = button
+
+        let activityIndicator = UIActivityIndicatorView(style: .medium)
+        activityIndicator.hidesWhenStopped = true
+        cardStack.addArrangedSubview(activityIndicator)
+        spinner = activityIndicator
+
+        // Layout
+        NSLayoutConstraint.activate([
+            fadedLabel.topAnchor.constraint(equalTo: container.topAnchor, constant: 16),
+            fadedLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            fadedLabel.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+
+            gradientContainer.topAnchor.constraint(equalTo: fadedLabel.topAnchor),
+            gradientContainer.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            gradientContainer.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            gradientContainer.heightAnchor.constraint(equalToConstant: 100),
+
+            card.topAnchor.constraint(equalTo: gradientContainer.bottomAnchor),
+            card.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            card.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            card.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            card.heightAnchor.constraint(greaterThanOrEqualToConstant: 200),
+
+            cardStack.centerXAnchor.constraint(equalTo: card.centerXAnchor),
+            cardStack.centerYAnchor.constraint(equalTo: card.centerYAnchor),
+            cardStack.leadingAnchor.constraint(greaterThanOrEqualTo: card.leadingAnchor, constant: 24),
+            cardStack.trailingAnchor.constraint(lessThanOrEqualTo: card.trailingAnchor, constant: -24),
+        ])
+
+        return container
+    }
+
+    private func wrapWithPadding(_ view: UIView) -> UIView {
+        let wrapper = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        wrapper.addSubview(view)
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: wrapper.topAnchor, constant: 8),
+            view.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor, constant: 16),
+            view.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor, constant: -16),
+            view.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor, constant: -8),
+        ])
+        return wrapper
+    }
+
+    // MARK: - Ad Loading
+
+    private func loadInterstitialAd() {
+        let request = Request()
+
+        InterstitialAd.load(with: pid, request: request) { [weak self] ad, error in
+            guard let self else { return }
+
+            if let error {
+                print("Interstitial ad failed to load: \(error.localizedDescription)")
+                return
+            }
+
+            guard let ad else { return }
+
+            ad.fullScreenContentDelegate = self
+            self.interstitialAd = ad
+
+            // If user already tapped "Watch Ad", show immediately
+            if self.isWaitingForAd {
+                self.presentInterstitial()
+            }
+        }
+    }
+
+    private func presentInterstitial() {
+        guard let interstitialAd else { return }
+        isWaitingForAd = false
+        spinner?.stopAnimating()
+        watchAdButton?.isHidden = false
+        interstitialAd.present(from: self)
+    }
+
+    @objc private func watchAdTapped() {
+        if let interstitialAd {
+            interstitialAd.present(from: self)
+        } else {
+            // Ad still loading — show spinner and wait
+            isWaitingForAd = true
+            watchAdButton?.isHidden = true
+            spinner?.startAnimating()
+        }
+    }
+
+    private func unlockContent() {
+        isContentUnlocked = true
+        interstitialAd = nil
+        rebuildContent()
+    }
+}
+
+// MARK: - FullScreenContentDelegate
+
+extension InterstitialAdmobViewController: FullScreenContentDelegate {
+    func adDidDismissFullScreenContent(_: FullScreenPresentingAd) {
+        unlockContent()
+    }
+
+    func ad(_: FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
+        print("Interstitial failed to present: \(error.localizedDescription)")
+        interstitialAd = nil
+        unlockContent()
+    }
+
+    func adDidRecordImpression(_: FullScreenPresentingAd) {
+        print("Interstitial: impression recorded")
+    }
+
+    func adDidRecordClick(_: FullScreenPresentingAd) {
+        print("Interstitial: click recorded")
+    }
+}
+
+// MARK: - Gradient View
+
+private class GradientView: UIView {
+    override class var layerClass: AnyClass { CAGradientLayer.self }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        guard let gradient = layer as? CAGradientLayer else { return }
+        gradient.colors = [
+            UIColor.systemBackground.withAlphaComponent(0).cgColor,
+            UIColor.systemBackground.cgColor,
+        ]
+        gradient.startPoint = CGPoint(x: 0.5, y: 0)
+        gradient.endPoint = CGPoint(x: 0.5, y: 1)
+    }
+}

--- a/TeadsSampleApp/Controllers/Interstitial/Admob/InterstitialAdmobViewController.swift
+++ b/TeadsSampleApp/Controllers/Interstitial/Admob/InterstitialAdmobViewController.swift
@@ -8,7 +8,8 @@
 import GoogleMobileAds
 import UIKit
 
-class InterstitialAdmobViewController: TeadsViewController {
+final class InterstitialAdmobViewController: TeadsViewController {
+
     private var interstitialAd: InterstitialAd?
     private var isContentUnlocked = false
     private var isWaitingForAd = false
@@ -19,42 +20,8 @@ class InterstitialAdmobViewController: TeadsViewController {
     private var watchAdButton: UIButton?
     private var spinner: UIActivityIndicatorView?
 
-    // Article paragraphs
-    private let articleTitle = "The Future of Digital Advertising"
-    private let previewParagraph = """
-    The digital advertising landscape is undergoing a profound transformation. \
-    As privacy regulations tighten and third-party cookies phase out, publishers \
-    and advertisers are rethinking how they connect with audiences. New formats \
-    like interstitial ads offer immersive, full-screen experiences that capture \
-    attention while respecting user choice.
-    """
-    private let lockedParagraphs = [
-        """
-        Interstitial ads have emerged as one of the most effective ad formats for mobile apps. \
-        Unlike banner ads that compete for attention within a crowded interface, interstitials \
-        command the full screen, delivering higher engagement rates and better brand recall. \
-        Publishers who integrate interstitials at natural transition points — between articles, \
-        levels, or content sections — see significantly improved monetization without sacrificing \
-        user experience.
-        """,
-        """
-        The key to successful interstitial implementation lies in timing and relevance. \
-        Ads shown at natural content breaks feel less intrusive than those interrupting \
-        active engagement. Combined with server-side optimization for ad quality and \
-        frequency capping, interstitials can achieve the delicate balance between revenue \
-        generation and user satisfaction that every publisher seeks.
-        """,
-        """
-        Looking ahead, the convergence of contextual targeting, first-party data, and \
-        premium ad formats like interstitials will define the next era of digital advertising. \
-        Publishers who invest in these capabilities today will be best positioned to thrive \
-        in a privacy-first world where user trust is the ultimate currency.
-        """,
-    ]
-
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .systemBackground
         setupUI()
         loadInterstitialAd()
     }
@@ -62,64 +29,62 @@ class InterstitialAdmobViewController: TeadsViewController {
     // MARK: - UI Setup
 
     private func setupUI() {
+        view.backgroundColor = .systemBackground
+
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(scrollView)
-        NSLayoutConstraint.activate([
-            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
 
         contentStack.axis = .vertical
         contentStack.spacing = 0
         contentStack.translatesAutoresizingMaskIntoConstraints = false
         scrollView.addSubview(contentStack)
+
+        setupConstraints()
+        rebuildContent()
+    }
+
+    private func setupConstraints() {
         NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+
             contentStack.topAnchor.constraint(equalTo: scrollView.topAnchor),
             contentStack.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
             contentStack.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
             contentStack.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
             contentStack.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
         ])
-
-        rebuildContent()
     }
 
     private func rebuildContent() {
         contentStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
 
-        // Title
         let titleLabel = UILabel()
-        titleLabel.text = articleTitle
+        titleLabel.text = ArticleContent.title
         titleLabel.font = .systemFont(ofSize: 24, weight: .bold)
         titleLabel.numberOfLines = 0
         titleLabel.textColor = .label
-        let titleWrapper = wrapWithPadding(titleLabel)
-        contentStack.addArrangedSubview(titleWrapper)
+        contentStack.addArrangedSubview(wrapWithPadding(titleLabel))
 
-        // Preview paragraph
         let previewLabel = UILabel()
-        previewLabel.text = previewParagraph
+        previewLabel.text = ArticleContent.previewParagraph
         previewLabel.font = .systemFont(ofSize: 16)
         previewLabel.numberOfLines = 0
         previewLabel.textColor = .secondaryLabel
-        let previewWrapper = wrapWithPadding(previewLabel)
-        contentStack.addArrangedSubview(previewWrapper)
+        contentStack.addArrangedSubview(wrapWithPadding(previewLabel))
 
         if isContentUnlocked {
-            // Show all locked paragraphs
-            for paragraph in lockedParagraphs {
+            for paragraph in ArticleContent.lockedParagraphs {
                 let label = UILabel()
                 label.text = paragraph
                 label.font = .systemFont(ofSize: 16)
                 label.numberOfLines = 0
                 label.textColor = .secondaryLabel
-                let wrapper = wrapWithPadding(label)
-                contentStack.addArrangedSubview(wrapper)
+                contentStack.addArrangedSubview(wrapWithPadding(label))
             }
         } else {
-            // Paywall overlay
             let paywall = buildPaywall()
             contentStack.addArrangedSubview(paywall)
             paywallContainer = paywall
@@ -130,21 +95,18 @@ class InterstitialAdmobViewController: TeadsViewController {
         let container = UIView()
         container.translatesAutoresizingMaskIntoConstraints = false
 
-        // Faded preview text
         let fadedLabel = UILabel()
-        fadedLabel.text = lockedParagraphs.first
+        fadedLabel.text = ArticleContent.lockedParagraphs.first
         fadedLabel.font = .systemFont(ofSize: 16)
         fadedLabel.numberOfLines = 4
         fadedLabel.textColor = .secondaryLabel
         fadedLabel.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(fadedLabel)
 
-        // Gradient overlay
         let gradientContainer = GradientView()
         gradientContainer.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(gradientContainer)
 
-        // Paywall card
         let card = UIView()
         card.backgroundColor = .secondarySystemBackground
         card.layer.cornerRadius = 12
@@ -152,7 +114,6 @@ class InterstitialAdmobViewController: TeadsViewController {
         card.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(card)
 
-        // Card content
         let cardStack = UIStackView()
         cardStack.axis = .vertical
         cardStack.alignment = .center
@@ -190,18 +151,23 @@ class InterstitialAdmobViewController: TeadsViewController {
         cardStack.addArrangedSubview(activityIndicator)
         spinner = activityIndicator
 
-        // Layout
+        setupPaywallConstraints(container: container, fadedLabel: fadedLabel, gradient: gradientContainer, card: card, cardStack: cardStack)
+
+        return container
+    }
+
+    private func setupPaywallConstraints(container: UIView, fadedLabel: UILabel, gradient: UIView, card: UIView, cardStack: UIStackView) {
         NSLayoutConstraint.activate([
             fadedLabel.topAnchor.constraint(equalTo: container.topAnchor, constant: 16),
             fadedLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
             fadedLabel.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
 
-            gradientContainer.topAnchor.constraint(equalTo: fadedLabel.topAnchor),
-            gradientContainer.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            gradientContainer.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-            gradientContainer.heightAnchor.constraint(equalToConstant: 100),
+            gradient.topAnchor.constraint(equalTo: fadedLabel.topAnchor),
+            gradient.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            gradient.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            gradient.heightAnchor.constraint(equalToConstant: 100),
 
-            card.topAnchor.constraint(equalTo: gradientContainer.bottomAnchor),
+            card.topAnchor.constraint(equalTo: gradient.bottomAnchor),
             card.leadingAnchor.constraint(equalTo: container.leadingAnchor),
             card.trailingAnchor.constraint(equalTo: container.trailingAnchor),
             card.bottomAnchor.constraint(equalTo: container.bottomAnchor),
@@ -212,8 +178,6 @@ class InterstitialAdmobViewController: TeadsViewController {
             cardStack.leadingAnchor.constraint(greaterThanOrEqualTo: card.leadingAnchor, constant: 24),
             cardStack.trailingAnchor.constraint(lessThanOrEqualTo: card.trailingAnchor, constant: -24),
         ])
-
-        return container
     }
 
     private func wrapWithPadding(_ view: UIView) -> UIView {
@@ -235,38 +199,37 @@ class InterstitialAdmobViewController: TeadsViewController {
         let request = Request()
 
         InterstitialAd.load(with: pid, request: request) { [weak self] ad, error in
-            guard let self else { return }
+            DispatchQueue.main.async {
+                guard let self else { return }
 
-            if let error {
-                print("Interstitial ad failed to load: \(error.localizedDescription)")
-                return
-            }
+                if let error {
+                    print("Interstitial ad failed to load: \(error.localizedDescription)")
+                    return
+                }
 
-            guard let ad else { return }
+                guard let ad else { return }
 
-            ad.fullScreenContentDelegate = self
-            self.interstitialAd = ad
+                ad.fullScreenContentDelegate = self
+                self.interstitialAd = ad
 
-            // If user already tapped "Watch Ad", show immediately
-            if self.isWaitingForAd {
-                self.presentInterstitial()
+                if self.isWaitingForAd {
+                    self.presentInterstitial(ad)
+                }
             }
         }
     }
 
-    private func presentInterstitial() {
-        guard let interstitialAd else { return }
+    private func presentInterstitial(_ ad: InterstitialAd) {
         isWaitingForAd = false
         spinner?.stopAnimating()
         watchAdButton?.isHidden = false
-        interstitialAd.present(from: self)
+        ad.present(from: self)
     }
 
     @objc private func watchAdTapped() {
         if let interstitialAd {
-            interstitialAd.present(from: self)
+            presentInterstitial(interstitialAd)
         } else {
-            // Ad still loading — show spinner and wait
             isWaitingForAd = true
             watchAdButton?.isHidden = true
             spinner?.startAnimating()
@@ -289,7 +252,6 @@ extension InterstitialAdmobViewController: FullScreenContentDelegate {
 
     func ad(_: FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
         print("Interstitial failed to present: \(error.localizedDescription)")
-        interstitialAd = nil
         unlockContent()
     }
 
@@ -304,7 +266,7 @@ extension InterstitialAdmobViewController: FullScreenContentDelegate {
 
 // MARK: - Gradient View
 
-private class GradientView: UIView {
+private final class GradientView: UIView {
     override class var layerClass: AnyClass { CAGradientLayer.self }
 
     override func layoutSubviews() {

--- a/TeadsSampleApp/Controllers/Interstitial/ArticleContent.swift
+++ b/TeadsSampleApp/Controllers/Interstitial/ArticleContent.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class ArticleContent {
+enum ArticleContent {
     static let title = "The Future of Digital Advertising"
 
     static let previewParagraph = """

--- a/TeadsSampleApp/Controllers/Interstitial/ArticleContent.swift
+++ b/TeadsSampleApp/Controllers/Interstitial/ArticleContent.swift
@@ -1,0 +1,44 @@
+//
+//  ArticleContent.swift
+//  TeadsSampleApp
+//
+//  Copyright © 2026 Teads. All rights reserved.
+//
+
+import Foundation
+
+final class ArticleContent {
+    static let title = "The Future of Digital Advertising"
+
+    static let previewParagraph = """
+    The digital advertising landscape is undergoing a profound transformation. \
+    As privacy regulations tighten and third-party cookies phase out, publishers \
+    and advertisers are rethinking how they connect with audiences. New formats \
+    like interstitial ads offer immersive, full-screen experiences that capture \
+    attention while respecting user choice.
+    """
+
+    static let lockedParagraphs = [
+        """
+        Interstitial ads have emerged as one of the most effective ad formats for mobile apps. \
+        Unlike banner ads that compete for attention within a crowded interface, interstitials \
+        command the full screen, delivering higher engagement rates and better brand recall. \
+        Publishers who integrate interstitials at natural transition points — between articles, \
+        levels, or content sections — see significantly improved monetization without sacrificing \
+        user experience.
+        """,
+        """
+        The key to successful interstitial implementation lies in timing and relevance. \
+        Ads shown at natural content breaks feel less intrusive than those interrupting \
+        active engagement. Combined with server-side optimization for ad quality and \
+        frequency capping, interstitials can achieve the delicate balance between revenue \
+        generation and user satisfaction that every publisher seeks.
+        """,
+        """
+        Looking ahead, the convergence of contextual targeting, first-party data, and \
+        premium ad formats like interstitials will define the next era of digital advertising. \
+        Publishers who invest in these capabilities today will be best positioned to thrive \
+        in a privacy-first world where user trust is the ultimate currency.
+        """,
+    ]
+}

--- a/TeadsSampleApp/Controllers/RootController/RootViewController.swift
+++ b/TeadsSampleApp/Controllers/RootController/RootViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 
 class RootViewController: TeadsViewController {
     @IBOutlet var collectionView: UICollectionView!
-    private var selectionList = [inReadFormat, nativeFormat]
+    private var selectionList = [inReadFormat, nativeFormat, interstitialFormat]
 
     private let headerCell = "RootHeaderCollectionReusableView"
     private let buttonCell = "RootButtonCollectionViewCell"
@@ -51,6 +51,15 @@ class RootViewController: TeadsViewController {
     }
 
     func showSampleController(for integration: Integration) {
+        // Interstitial is programmatic — no storyboard segue
+        if adSelection.format.name == .interstitial {
+            let vc = InterstitialAdmobViewController()
+            vc.pid = PID.admobInterstitial
+            vc.validationModeEnabled = validationModeEnabled
+            navigationController?.pushViewController(vc, animated: true)
+            return
+        }
+
         let identifier = "\(adSelection.format.name)-\(adSelection.provider.name)-\(integration.name)"
             .lowercased()
         performSegue(withIdentifier: identifier, sender: self)
@@ -77,6 +86,9 @@ class RootViewController: TeadsViewController {
     }
 
     private func pidForCreative() -> String {
+        if adSelection.format.name == .interstitial {
+            return PID.admobInterstitial
+        }
         switch adSelection.provider.name {
             case .direct:
                 switch adSelection.creation.name {

--- a/TeadsSampleApp/Models/Format.swift
+++ b/TeadsSampleApp/Models/Format.swift
@@ -51,11 +51,12 @@ struct Integration {
 
 // Formats
 enum Formats {
-    case inRead, native
+    case inRead, native, interstitial
     func format() -> Format {
         switch self {
             case .inRead: return inReadFormat
             case .native: return nativeFormat
+            case .interstitial: return interstitialFormat
         }
     }
 }
@@ -65,6 +66,7 @@ let appLovinInReadCreativeTypes = [landscape, vertical, square, carousel, appLov
 
 let inReadFormat = Format(name: .inRead, providers: [inReadDirectProvider, inReadAdmobProvider, inReadAppLovinProvider, inReadSASProvider], isSelected: true, creativeTypes: defaultInReadCreativeTypes)
 let nativeFormat = Format(name: .native, providers: [nativeDirectProvider, nativeAdmobProvider, nativeAppLovinProvider, nativeSASProvider], isSelected: false, creativeTypes: [display, custom])
+let interstitialFormat = Format(name: .interstitial, providers: [interstitialAdmobProvider], isSelected: false, creativeTypes: [])
 
 // inRead Providers
 let inReadDirectProvider = Provider(name: .direct, integrations: [
@@ -86,6 +88,9 @@ let inReadSASProvider = Provider(name: .sas, integrations: [
 let inReadAppLovinProvider = Provider(name: .appLovin, integrations: [
     scrollViewIntegration,
 ], isSelected: false)
+
+// Interstitial Providers
+let interstitialAdmobProvider = Provider(name: .admob, integrations: [scrollViewIntegration], isSelected: true)
 
 // Native Providers
 let nativeDirectProvider = Provider(name: .direct, integrations: [
@@ -162,11 +167,15 @@ enum PID {
     static let appLovinSquare = "4df06edb6937371e"
     static let appLovinCarousel = "373d7d2b25d2d8cc"
     static let appLovinNativeDisplay = "5738024757e4ef72"
+
+    static let admobInterstitial = "ca-app-pub-3068786746829754/9358977978"
+    static let admobInterstitialTest = "ca-app-pub-3940256099942544/4411468910"
 }
 
 enum FormatName: String {
     case inRead
     case native = "Native"
+    case interstitial = "Interstitial"
 }
 
 enum ProviderName: String {


### PR DESCRIPTION
## Summary
- Add `InterstitialAdmobViewController` — article with paywall overlay that loads an AdMob interstitial and unlocks content on dismiss (matches Android PR #263)
- Add `Interstitial` format to the demo app with AdMob provider
- Wire up navigation: Format → Provider → ScrollView integration → programmatic push

## Dependencies
- Requires SDK **6.1.0** — the interstitial adapter (`GADMAdapterTeadsInterstitial`) is not yet included in the published xcframework
- Merge after 6.1.0 release

## Test plan
- [ ] Select Format = Interstitial → only AdMob shown as provider
- [ ] Tap AdMob → ScrollView integration button appears
- [ ] Tap ScrollView → opens article with paywall overlay
- [ ] Tap "Watch Ad" → interstitial loads and presents
- [ ] After ad dismissal → full article content unlocked
- [ ] Existing formats (InRead, Native) still work