### PR TITLE
Extend GMA SPM dependency range to support version 13

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/AppLovin/AppLovin-MAX-Swift-Package.git",
         "state": {
           "branch": null,
-          "revision": "c184b428415a05dcad488c6834e0bd02fe1d8f3e",
-          "version": "13.3.1"
+          "revision": "d829feb5b7de8755e9a1834c2e1e0b95c9126424",
+          "version": "13.6.2"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/prebid/prebid-mobile-ios.git",
         "state": {
           "branch": null,
-          "revision": "a59bc756e22813ca76a55abda5db96edf9ede75e",
-          "version": "3.2.1"
+          "revision": "0c276ce9590ffe365d949217ddd51aeb4441a61a",
+          "version": "3.3.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
         "state": {
           "branch": null,
-          "revision": "49efd19f8f4bbe130de7e2ee9e061d202a9a2a8b",
-          "version": "12.8.0"
+          "revision": "8d08e4396ea955a7d2baf067c0eedfc34ca0821d",
+          "version": "13.2.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git",
         "state": {
           "branch": null,
-          "revision": "69b53394c5258b3fe688e625a998047d1f393497",
-          "version": "3.0.0"
+          "revision": "13b248eaa73b7826f0efb1bcf455e251d65ecb1b",
+          "version": "3.1.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let package = Package(
         .package(
             name: googleMobileAdsModuleName,
             url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
-            "12.2.0" ..< "13.0.0"
+            "12.2.0" ..< "14.0.0"
         ),
         .package(
             name: appLovinMaxModuleName,


### PR DESCRIPTION
## Summary
- Widens the Google Mobile Ads SPM dependency range from `12.2.0 ..< 13.0.0` to `12.2.0 ..< 14.0.0`
- Aligns SPM with the podspec which already supports GMA >= 12.2.0 with no upper cap
- Updates `Package.resolved` with latest resolved versions (GMA 13.2.0, Prebid 3.3.0)

## Test plan
- [ ] Verify `swift package resolve` succeeds
- [ ] Verify GMA resolves to 13.x
- [ ] Test AdMob adapter builds against GMA 13