### PR TITLE
INAPP-205: Automate git tagging on release

### DIFF
--- a/TeadsSDK.podspec
+++ b/TeadsSDK.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
     s.homepage              = "https://github.com/teads/TeadsSDK-iOS"
     s.license               = { :type => 'Copyright', :text => 'Copyright Teads 2021' }
     s.author                = { "Teads" => "support-sdk@teads.tv" }
-    s.source                = { :git => 'https://github.com/teads/TeadsSDK-iOS.git', :branch => 'master', :tag => "#{s.version}"}
+    s.source                = { :git => 'https://github.com/teads/TeadsSDK-iOS.git', :branch => 'master', :tag => "v#{s.version}"}
     
     s.requires_arc          = true
     

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,12 @@
+default_platform(:ios)
+
+platform :ios do
+  desc "Tag the current release commit using the version from TeadsSDK.podspec and push to remote"
+  lane :tag_release do
+    version = get_podspec_version(path: "TeadsSDK.podspec")
+    tag = "v#{version}"
+    add_git_tag(tag: tag)
+    push_git_tags(tag: tag)
+    UI.success("Tagged and pushed #{tag}")
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a `tag_release` Fastlane lane that reads the version from `TeadsSDK.podspec`, creates a git tag (e.g. `v6.2.0`), and pushes it to remote
- This tag serves as the anchor for detecting commits since the last release (used by the automated release notes lane, to be merged here)
- Backfilled `v6.1.0` tag on the correct release commit

## Notes

- The release notes PR (ART-898) will be merged into this branch before merging to master
- Calling `bundle exec fastlane tag_release` from the InappSDK release pipeline will be wired up in a follow-up

Jira: https://teads.atlassian.net/browse/INAPP-205